### PR TITLE
fix double counting fee value

### DIFF
--- a/contracts.json
+++ b/contracts.json
@@ -1,9 +1,7 @@
 {
   "base_mainnet": {
     "vault": "0xf0c7055623949b963d4a2cad30a872bfb05e5281",
-    "vaultAutomator": [
-      "0x36330a24ed9cca06373296eb576898fa188eac15"
-    ],
+    "vaultAutomator": ["0x36330a24ed9cca06373296eb576898fa188eac15"],
     "poolOptimalSwapper": "0xd96267bf1afbf065a742ba62baa96935b0162c9e",
     "configManager": "0xa4e7252f30ed9ca9ddd69958068fab3bf9be69bc",
     "lpStrategy": "0xb315fb00de89553ddd4d019ef7cff75dde570dc3",

--- a/docs/strategies/lpUniV3/LpStrategy.md
+++ b/docs/strategies/lpUniV3/LpStrategy.md
@@ -20,19 +20,6 @@ contract IConfigManager configManager
 constructor(address _optimalSwapper, address _configManager) public
 ```
 
-### ValuationVars
-
-_Struct to store variables used for asset valuation, including token amounts and fees._
-
-```solidity
-struct ValuationVars {
-  uint256 amount0;
-  uint256 amount1;
-  uint256 fee0;
-  uint256 fee1;
-}
-```
-
 ### valueOf
 
 ```solidity


### PR DESCRIPTION
At first, I though we just need to change like this (remove the fee in here):
```
if (token0 == principalToken) {
      priceX96 = FullMath.mulDiv(FixedPoint96.Q96, FixedPoint96.Q96, priceX96);
      valueInPrincipal = amount0 + FullMath.mulDiv(amount1, priceX96, FixedPoint96.Q96);
    } else {
      valueInPrincipal = amount1  + FullMath.mulDiv(amount0, priceX96, FixedPoint96.Q96);
}
```
However, this error occur when I ran `forge test`:
`
Variable _85 is 1 too deep in the stack 
[ _85 var_amount1 _63 value1_3 var_amount0 value0_4 expr_component_106 _78 expr_component_100 expr_component_119 expr_component_104 expr_component_102 expr_component_105 expr_component_101 expr_component_128 expr_component_103 expr_component_127 ]
`

So I have to use this:
```
/// @dev Struct to store variables used for asset valuation, including token amounts and fees.
  struct ValuationVars {
    uint256 amount0; // Amount of token0 in the position
    uint256 amount1; // Amount of token1 in the position
    uint256 fee0;    // Accumulated fee for token0
    uint256 fee1;    // Accumulated fee for token1
  }
```
