### PR TITLE
chore: deploy private vaults contract on Ethereum

### DIFF
--- a/configs/config_eth.ts
+++ b/configs/config_eth.ts
@@ -18,7 +18,15 @@ const PrivateConfig: Record<string, IConfigPrivate> = {
       enabled: true,
       autoVerifyContract: true,
     },
-    privateAerodromeFarmingStrategy: {
+    privatePancakeV3FarmingStrategy: {
+      enabled: true,
+      autoVerifyContract: true,
+    },
+    privateMerklStrategy: {
+      enabled: true,
+      autoVerifyContract: true,
+    },
+    privateKyberFairFlowStrategy: {
       enabled: true,
       autoVerifyContract: true,
     },
@@ -30,9 +38,11 @@ const PrivateConfig: Record<string, IConfigPrivate> = {
       enabled: true,
       autoVerifyContract: true,
     },
-    v3UtilsAddress: "0x3A7e46212Ac7d61E44bb9bA926E3737Af5A65EC6",
-    v4UtilsAddress: "0xE91D4cC5d8b97379d740A1f19c728EAb76A16228",
+    v3UtilsAddress: "0x56fc6ac4af3007c4ae36f239cb0f8028ade73519",
+    v4UtilsAddress: "0xCb3d2a42022741B06f9B38459e3DD1Ee9A64D129",
     pancakeV3MasterChef: "0x556B9306565093C855AEA9AE92A594704c2Cd59e",
+    merklDistributor: "0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae",
+    uniswapV4KEMHook: "0x4440854B2d02C57A0Dc5c58b7A884562D875c0c4",
   },
 };
 

--- a/contracts-private.json
+++ b/contracts-private.json
@@ -33,6 +33,17 @@
     "v3UtilsStrategy": "0x3d9114ea5965000ac702faffcc77f7626d93aa7b",
     "v4UtilsStrategy": "0xcae856d2316ae2e6e0655b7ef2b093cb38d78b82"
   },
+  "eth_mainnet": {
+    "privateConfigManager": "0x4cb65229b25abafdf9e08b0452ec40c20ea4ecba",
+    "privateVault": "0x34c1b3f20c83f0d959ea8ff5a6d37960bd2362e3",
+    "privateVaultFactory": "0x99029ddf03de6446524f7ffa6585458b58dc1eee",
+    "privateVaultAutomator": "0x0fb6e8ecd8ca55c79122f4e114fb46afe1924089",
+    "pancakeV3FarmingStrategy": "0x81701f061e7f5510e2d95e399cbec611bacb3c4c",
+    "privateMerklStrategy": "0x4e4ba610e4be48c3ae4340da818b110645b394e8",
+    "privateKyberFairFlowStrategy": "0xe22fe2b8c57bd9d0f668448a94276e64ec2ba657",
+    "v3UtilsStrategy": "0xa863e20e6aeca048ddd8656f82eed21860cef37d",
+    "v4UtilsStrategy": "0xcae856d2316ae2e6e0655b7ef2b093cb38d78b82"
+  },
   "polygon_mainnet": {
     "privateConfigManager": "0x4cb65229b25abafdf9e08b0452ec40c20ea4ecba",
     "privateVault": "0x34c1b3f20c83f0d959ea8ff5a6d37960bd2362e3",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it updates mainnet contract addresses and enables additional private strategy deployments; misconfigured addresses would break on-chain interactions or deployments.
> 
> **Overview**
> Updates Ethereum private deployment config by switching from `privateAerodromeFarmingStrategy` to enabling `privatePancakeV3FarmingStrategy`, and adds `privateMerklStrategy` / `privateKyberFairFlowStrategy` flags plus new on-chain dependency addresses (`merklDistributor`, `uniswapV4KEMHook`).
> 
> Rotates Ethereum `v3UtilsAddress`/`v4UtilsAddress` in `configs/config_eth.ts`, and adds an `eth_mainnet` entry to `contracts-private.json` with the corresponding deployed contract addresses (including an updated `v3UtilsStrategy`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c7861b5fbf320959713383119d4667d3d1ac57e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->