### PR TITLE
chore: redeploy V3UtilsStrategy

### DIFF
--- a/configs/config_arbitrum.ts
+++ b/configs/config_arbitrum.ts
@@ -38,7 +38,7 @@ const PrivateConfig: Record<string, IConfigPrivate> = {
       enabled: true,
       autoVerifyContract: true,
     },
-    v3UtilsAddress: "0xb0717286fca964cb7315a95a003e1c3f0313b6de",
+    v3UtilsAddress: "0xb4acbc082b5e7ded571c98ee4257778a9d784b36",
     v4UtilsAddress: "0xCb3d2a42022741B06f9B38459e3DD1Ee9A64D129",
     pancakeV3MasterChef: "0x5e09ACf80C0296740eC5d6F643005a4ef8DaA694",
     merklDistributor: "0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae",

--- a/configs/config_base.ts
+++ b/configs/config_base.ts
@@ -42,7 +42,7 @@ const PrivateConfig: Record<string, IConfigPrivate> = {
       enabled: true,
       autoVerifyContract: true,
     },
-    v3UtilsAddress: "0xb0717286fca964cb7315a95a003e1c3f0313b6de",
+    v3UtilsAddress: "0xb4acbc082b5e7ded571c98ee4257778a9d784b36",
     v4UtilsAddress: "0xCb3d2a42022741B06f9B38459e3DD1Ee9A64D129",
     aerodromeGaugeFactory: "0xD30677bd8dd15132F251Cb54CbDA552d2A05Fb08",
     pancakeV3MasterChef: "0xC6A2Db661D5a5690172d8eB0a7DEA2d3008665A3",

--- a/configs/config_bsc.ts
+++ b/configs/config_bsc.ts
@@ -38,7 +38,7 @@ const PrivateConfig: Record<string, IConfigPrivate> = {
       enabled: true,
       autoVerifyContract: true,
     },
-    v3UtilsAddress: "0xb0717286fca964cb7315a95a003e1c3f0313b6de",
+    v3UtilsAddress: "0xb4acbc082b5e7ded571c98ee4257778a9d784b36",
     v4UtilsAddress: "0xCb3d2a42022741B06f9B38459e3DD1Ee9A64D129",
     pancakeV3MasterChef: "0x556B9306565093C855AEA9AE92A594704c2Cd59e",
     merklDistributor: "0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae",

--- a/configs/config_eth.ts
+++ b/configs/config_eth.ts
@@ -38,7 +38,7 @@ const PrivateConfig: Record<string, IConfigPrivate> = {
       enabled: true,
       autoVerifyContract: true,
     },
-    v3UtilsAddress: "0x56fc6ac4af3007c4ae36f239cb0f8028ade73519",
+    v3UtilsAddress: "0xb4acbc082b5e7ded571c98ee4257778a9d784b36",
     v4UtilsAddress: "0xCb3d2a42022741B06f9B38459e3DD1Ee9A64D129",
     pancakeV3MasterChef: "0x556B9306565093C855AEA9AE92A594704c2Cd59e",
     merklDistributor: "0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae",

--- a/configs/config_optimism.ts
+++ b/configs/config_optimism.ts
@@ -30,7 +30,7 @@ const PrivateConfig: Record<string, IConfigPrivate> = {
       enabled: true,
       autoVerifyContract: true,
     },
-    v3UtilsAddress: "0x3A7e46212Ac7d61E44bb9bA926E3737Af5A65EC6",
+    v3UtilsAddress: "0xb4acbc082b5e7ded571c98ee4257778a9d784b36",
     v4UtilsAddress: "0xE91D4cC5d8b97379d740A1f19c728EAb76A16228",
   },
 };

--- a/configs/config_polygon.ts
+++ b/configs/config_polygon.ts
@@ -30,7 +30,7 @@ const PrivateConfig: Record<string, IConfigPrivate> = {
       enabled: true,
       autoVerifyContract: true,
     },
-    v3UtilsAddress: "0x56fc6ac4af3007c4ae36f239cb0f8028ade73519",
+    v3UtilsAddress: "0xb4acbc082b5e7ded571c98ee4257778a9d784b36",
     v4UtilsAddress: "0xCb3d2a42022741B06f9B38459e3DD1Ee9A64D129",
     merklDistributor: "0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae",
   },

--- a/contracts-private.json
+++ b/contracts-private.json
@@ -7,7 +7,7 @@
     "pancakeV3FarmingStrategy": "0x233aff78b6bf001ce257d6c1ffa321c3291e54e4",
     "privateMerklStrategy": "0x4e4ba610e4be48c3ae4340da818b110645b394e8",
     "privateKyberFairFlowStrategy": "0xe22fe2b8c57bd9d0f668448a94276e64ec2ba657",
-    "v3UtilsStrategy": "0x3d9114ea5965000ac702faffcc77f7626d93aa7b",
+    "v3UtilsStrategy": "0xea8809590b90465ede6e0ecd4ac1c1b9f20894da",
     "v4UtilsStrategy": "0xcae856d2316ae2e6e0655b7ef2b093cb38d78b82"
   },
   "base_mainnet": {
@@ -19,7 +19,7 @@
     "pancakeV3FarmingStrategy": "0x5f8e7e03bfd8fb868c2777b2fa95eb59ce03f439",
     "privateMerklStrategy": "0x4e4ba610e4be48c3ae4340da818b110645b394e8",
     "privateKyberFairFlowStrategy": "0xe22fe2b8c57bd9d0f668448a94276e64ec2ba657",
-    "v3UtilsStrategy": "0x3d9114ea5965000ac702faffcc77f7626d93aa7b",
+    "v3UtilsStrategy": "0xea8809590b90465ede6e0ecd4ac1c1b9f20894da",
     "v4UtilsStrategy": "0xcae856d2316ae2e6e0655b7ef2b093cb38d78b82"
   },
   "bsc_mainnet": {
@@ -30,7 +30,7 @@
     "pancakeV3FarmingStrategy": "0x81701f061e7f5510e2d95e399cbec611bacb3c4c",
     "privateMerklStrategy": "0x4e4ba610e4be48c3ae4340da818b110645b394e8",
     "privateKyberFairFlowStrategy": "0xe22fe2b8c57bd9d0f668448a94276e64ec2ba657",
-    "v3UtilsStrategy": "0x3d9114ea5965000ac702faffcc77f7626d93aa7b",
+    "v3UtilsStrategy": "0xea8809590b90465ede6e0ecd4ac1c1b9f20894da",
     "v4UtilsStrategy": "0xcae856d2316ae2e6e0655b7ef2b093cb38d78b82"
   },
   "eth_mainnet": {
@@ -41,7 +41,7 @@
     "pancakeV3FarmingStrategy": "0x81701f061e7f5510e2d95e399cbec611bacb3c4c",
     "privateMerklStrategy": "0x4e4ba610e4be48c3ae4340da818b110645b394e8",
     "privateKyberFairFlowStrategy": "0xe22fe2b8c57bd9d0f668448a94276e64ec2ba657",
-    "v3UtilsStrategy": "0xa863e20e6aeca048ddd8656f82eed21860cef37d",
+    "v3UtilsStrategy": "0xea8809590b90465ede6e0ecd4ac1c1b9f20894da",
     "v4UtilsStrategy": "0xcae856d2316ae2e6e0655b7ef2b093cb38d78b82"
   },
   "polygon_mainnet": {
@@ -50,7 +50,7 @@
     "privateVaultFactory": "0x99029ddf03de6446524f7ffa6585458b58dc1eee",
     "privateVaultAutomator": "0x0fb6e8ecd8ca55c79122f4e114fb46afe1924089",
     "privateMerklStrategy": "0x4e4ba610e4be48c3ae4340da818b110645b394e8",
-    "v3UtilsStrategy": "0xa863e20e6aeca048ddd8656f82eed21860cef37d",
+    "v3UtilsStrategy": "0xea8809590b90465ede6e0ecd4ac1c1b9f20894da",
     "v4UtilsStrategy": "0xcae856d2316ae2e6e0655b7ef2b093cb38d78b82"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates on-chain contract addresses used by multiple network configurations; risk is primarily misconfiguration leading to calls against the wrong deployed contracts.
> 
> **Overview**
> Replaces the configured `v3UtilsAddress` in the private config for Arbitrum, Base, BSC, Ethereum, Optimism, and Polygon to a new shared deployment address.
> 
> Updates `contracts-private.json` to point each network’s `v3UtilsStrategy` to the redeployed contract address.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 880b7ee8d9d555f97a8da54aa21ab2efd2e31753. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->