### PR TITLE
feat: add approve tokenId

### DIFF
--- a/abi/contracts/private-vault/strategies/lpv4/V4UtilsStrategy.sol/V4UtilsStrategy.json
+++ b/abi/contracts/private-vault/strategies/lpv4/V4UtilsStrategy.sol/V4UtilsStrategy.json
@@ -34,6 +34,11 @@
         "type": "address"
       },
       {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
         "internalType": "bytes",
         "name": "params",
         "type": "bytes"

--- a/contracts-private.json
+++ b/contracts-private.json
@@ -8,7 +8,7 @@
     "privateMerklStrategy": "0x4e4ba610e4be48c3ae4340da818b110645b394e8",
     "privateKyberFairFlowStrategy": "0xe22fe2b8c57bd9d0f668448a94276e64ec2ba657",
     "v3UtilsStrategy": "0xea8809590b90465ede6e0ecd4ac1c1b9f20894da",
-    "v4UtilsStrategy": "0xcae856d2316ae2e6e0655b7ef2b093cb38d78b82"
+    "v4UtilsStrategy": "0xdd66a0ba27b4ae1b960c5597345adfcd266f6bab"
   },
   "base_mainnet": {
     "privateVault": "0x34c1b3f20c83f0d959ea8ff5a6d37960bd2362e3",
@@ -20,7 +20,7 @@
     "privateMerklStrategy": "0x4e4ba610e4be48c3ae4340da818b110645b394e8",
     "privateKyberFairFlowStrategy": "0xe22fe2b8c57bd9d0f668448a94276e64ec2ba657",
     "v3UtilsStrategy": "0xea8809590b90465ede6e0ecd4ac1c1b9f20894da",
-    "v4UtilsStrategy": "0xcae856d2316ae2e6e0655b7ef2b093cb38d78b82"
+    "v4UtilsStrategy": "0xdd66a0ba27b4ae1b960c5597345adfcd266f6bab"
   },
   "bsc_mainnet": {
     "privateConfigManager": "0x4cb65229b25abafdf9e08b0452ec40c20ea4ecba",
@@ -31,7 +31,7 @@
     "privateMerklStrategy": "0x4e4ba610e4be48c3ae4340da818b110645b394e8",
     "privateKyberFairFlowStrategy": "0xe22fe2b8c57bd9d0f668448a94276e64ec2ba657",
     "v3UtilsStrategy": "0xea8809590b90465ede6e0ecd4ac1c1b9f20894da",
-    "v4UtilsStrategy": "0xcae856d2316ae2e6e0655b7ef2b093cb38d78b82"
+    "v4UtilsStrategy": "0xdd66a0ba27b4ae1b960c5597345adfcd266f6bab"
   },
   "eth_mainnet": {
     "privateConfigManager": "0x4cb65229b25abafdf9e08b0452ec40c20ea4ecba",
@@ -42,7 +42,7 @@
     "privateMerklStrategy": "0x4e4ba610e4be48c3ae4340da818b110645b394e8",
     "privateKyberFairFlowStrategy": "0xe22fe2b8c57bd9d0f668448a94276e64ec2ba657",
     "v3UtilsStrategy": "0xea8809590b90465ede6e0ecd4ac1c1b9f20894da",
-    "v4UtilsStrategy": "0xcae856d2316ae2e6e0655b7ef2b093cb38d78b82"
+    "v4UtilsStrategy": "0xdd66a0ba27b4ae1b960c5597345adfcd266f6bab"
   },
   "polygon_mainnet": {
     "privateConfigManager": "0x4cb65229b25abafdf9e08b0452ec40c20ea4ecba",
@@ -51,6 +51,6 @@
     "privateVaultAutomator": "0x0fb6e8ecd8ca55c79122f4e114fb46afe1924089",
     "privateMerklStrategy": "0x4e4ba610e4be48c3ae4340da818b110645b394e8",
     "v3UtilsStrategy": "0xea8809590b90465ede6e0ecd4ac1c1b9f20894da",
-    "v4UtilsStrategy": "0xcae856d2316ae2e6e0655b7ef2b093cb38d78b82"
+    "v4UtilsStrategy": "0xdd66a0ba27b4ae1b960c5597345adfcd266f6bab"
   }
 }

--- a/contracts/private-vault/strategies/lpv4/V4UtilsStrategy.sol
+++ b/contracts/private-vault/strategies/lpv4/V4UtilsStrategy.sol
@@ -54,7 +54,7 @@ contract V4UtilsStrategy {
     uint256 nativeBefore;
     if (returnLeftOverToOwner) (amountsBefore, nativeBefore) = SkimLib.snapshotBalances(tokens);
 
-    IERC721(posm).approve(v4UtilsRouter, tokenId);
+    if (tokenId != 0) IERC721(posm).approve(v4UtilsRouter, tokenId);
     IV4UtilsRouter(v4UtilsRouter).execute{ value: ethValue }(posm, params);
 
     if (returnLeftOverToOwner) {

--- a/contracts/private-vault/strategies/lpv4/V4UtilsStrategy.sol
+++ b/contracts/private-vault/strategies/lpv4/V4UtilsStrategy.sol
@@ -39,6 +39,7 @@ contract V4UtilsStrategy {
 
   function execute(
     address posm,
+    uint256 tokenId,
     bytes calldata params,
     uint256 ethValue,
     address[] calldata tokens,
@@ -53,6 +54,7 @@ contract V4UtilsStrategy {
     uint256 nativeBefore;
     if (returnLeftOverToOwner) (amountsBefore, nativeBefore) = SkimLib.snapshotBalances(tokens);
 
+    IERC721(posm).approve(v4UtilsRouter, tokenId);
     IV4UtilsRouter(v4UtilsRouter).execute{ value: ethValue }(posm, params);
 
     if (returnLeftOverToOwner) {

--- a/docs/private-vault/strategies/lpv4/V4UtilsStrategy.md
+++ b/docs/private-vault/strategies/lpv4/V4UtilsStrategy.md
@@ -23,6 +23,6 @@ function safeTransferNft(address posm, uint256 tokenId, bytes instruction, addre
 ### execute
 
 ```solidity
-function execute(address posm, bytes params, uint256 ethValue, address[] tokens, uint256[] approveAmounts, bool returnLeftOverToOwner) external payable
+function execute(address posm, uint256 tokenId, bytes params, uint256 ethValue, address[] tokens, uint256[] approveAmounts, bool returnLeftOverToOwner) external payable
 ```
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the on-chain call flow and external interface of `execute`, requiring client updates and careful validation that the new approval path doesn’t enable unintended NFT transfers.
> 
> **Overview**
> **Adds optional NFT approval support to `V4UtilsStrategy.execute`.** The `execute` function now takes a `tokenId` and, when non-zero, approves that ERC-721 (`posm`, `tokenId`) for the `v4UtilsRouter` before calling `IV4UtilsRouter.execute`.
> 
> Updates the published ABI (`V4UtilsStrategy.json`) and strategy docs to reflect the new `execute` signature, and bumps `contracts-private.json` `v4UtilsStrategy` addresses across all listed mainnets to a new deployment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e897c289ea21e2d53c851319e9857e12290935e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->