### PR TITLE
transfer shares from factory to owner

### DIFF
--- a/contracts/shared-vault/core/SharedVaultFactory.sol
+++ b/contracts/shared-vault/core/SharedVaultFactory.sol
@@ -69,6 +69,11 @@ contract SharedVaultFactory is OwnableUpgradeable, PausableUpgradeable, Withdraw
     }
 
     ISharedVault(vault).transferOwnership(_msgSender());
+
+    uint256 sharesBal = IERC20(vault).balanceOf(address(this));
+    if (sharesBal > 0) {
+      IERC20(vault).safeTransfer(_msgSender(), sharesBal);
+    }
   }
 
   function _createVault(

--- a/contracts/shared-vault/core/SharedVaultFactory.sol
+++ b/contracts/shared-vault/core/SharedVaultFactory.sol
@@ -70,6 +70,8 @@ contract SharedVaultFactory is OwnableUpgradeable, PausableUpgradeable, Withdraw
 
     ISharedVault(vault).transferOwnership(_msgSender());
 
+    // INITIAL_SHARES were minted to address(this) as the temporary vaultOwner during init.
+    // Transfer them to the actual caller now that setup is complete.
     uint256 sharesBal = IERC20(vault).balanceOf(address(this));
     if (sharesBal > 0) {
       IERC20(vault).safeTransfer(_msgSender(), sharesBal);

--- a/test/unit/SharedVaultFactory.t.sol
+++ b/test/unit/SharedVaultFactory.t.sol
@@ -351,6 +351,10 @@ contract SharedVaultFactoryTest is TestCommon {
     assertTrue(factory.isVault(vaultAddr));
     // Strategy was called and returned a PositionChange — vault should have tracked it
     assertEq(ISharedVault(vaultAddr).getPositionCount(), 1);
+
+    uint256 expectedInitialShares = SharedVault(payable(vaultAddr)).INITIAL_SHARES();
+    assertEq(IERC20(vaultAddr).balanceOf(VAULT_CREATOR), expectedInitialShares);
+    assertEq(IERC20(vaultAddr).balanceOf(address(factory)), 0);
   }
 
   function test_createVault_with_multiple_strategies() public {
@@ -491,6 +495,10 @@ contract SharedVaultFactoryTest is TestCommon {
     assertEq(tokenA.balanceOf(vaultAddr), 100e18);
     assertEq(tokenB.balanceOf(vaultAddr), 100e18);
     assertEq(mockWeth.balanceOf(vaultAddr), 0);
+
+    uint256 expectedInitialShares = SharedVault(payable(vaultAddr)).INITIAL_SHARES();
+    assertEq(IERC20(vaultAddr).balanceOf(VAULT_CREATOR), expectedInitialShares);
+    assertEq(IERC20(vaultAddr).balanceOf(address(factory)), 0);
   }
 
   /// @notice Batch createVault: native ETH msg.value must match WETH initial amount; strategies run with callValues from factory balance (zero here)
@@ -518,6 +526,10 @@ contract SharedVaultFactoryTest is TestCommon {
     assertEq(mockWeth.balanceOf(vaultAddr), 1 ether, "WETH wrapped from ETH deposit");
     assertEq(tokenA.balanceOf(vaultAddr), 100e18, "tokenA transferred as ERC20");
     assertEq(address(factory).balance, 0);
+
+    uint256 expectedInitialShares = SharedVault(payable(vaultAddr)).INITIAL_SHARES();
+    assertEq(IERC20(vaultAddr).balanceOf(VAULT_CREATOR), expectedInitialShares);
+    assertEq(IERC20(vaultAddr).balanceOf(address(factory)), 0);
   }
 
   /// @notice When paying WETH initial deposit via msg.value, it must equal initialAmounts[wethIndex] exactly


### PR DESCRIPTION
## Factory createVault with actions mints initial shares to the factory
When using SharedVaultFactory.createVault(..., actions), the vault is initialized with vaultOwner = address(factory), which causes the initial INITIAL_SHARES to be minted to the factory contract instead of the user who provided the initial deposits, permanently breaking user withdrawals for that initial funding.

## Impact
Any user who creates a vault using the createVault(..., actions) overload while providing non-zero initialAmounts will not receive the initial shares representing their deposit. Without shares, they cannot call withdraw() for their initial funding. The initial shares remain trapped in the factory contract and can only be used if the factory contract itself transfers/burns them; in practice this creates a direct loss-of-funds condition for affected users (and a central point where the platform could withdraw those underlying assets by redeeming the shares it holds).

## Proof of concept
Call SharedVaultFactory.createVault(name, tokens, initialAmounts, actions) with any initialAmounts[i] > 0.
Observe that IERC20(vault).balanceOf(msg.sender) == 0 while IERC20(vault).balanceOf(address(factory)) == INITIAL_SHARES.
The caller cannot withdraw the initial deposits (no shares), but the factory-held shares can be redeemed to withdraw the underlying assets.

## Remediation
Ensure the initial shares minted during vault creation are assigned to the depositor. Options include: (a) after execute, have the factory call IERC20(vault).transfer(_msgSender(), INITIAL_SHARES) (and ensure the factory can call it), (b) change SharedVault.initialize(...) to accept separate parameters for vaultOwner and initialSharesRecipient, using the user as the share recipient while keeping factory as temporary vaultOwner for the initial execute, or (c) avoid temporary factory ownership by authorizing the factory via config (e.g., whitelist the factory as a caller) so the vault can be initialized with the user as vaultOwner and share recipient.