### PR TITLE
chore: scope claude review to contracts/test and add incremental-push…

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, ready_for_review, reopened]
+    paths:
+      - 'contracts/**'
+      - 'test/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -23,7 +26,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code
         id: claude
@@ -36,6 +39,7 @@ jobs:
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
+            EVENT: ${{ github.event.action }}
 
             Please review this pull request with a focus on:
             - Code quality and best practices
@@ -45,9 +49,14 @@ jobs:
 
             Be concise and actionable.
 
+            IMPORTANT: If EVENT is "synchronize", review ONLY the incremental diff introduced
+            by this push — run `git diff ${{ github.event.before }} ${{ github.event.after }}`
+            to get the exact files changed. Do not re-review code already present in the PR
+            before this push.
+
             Provide detailed feedback using inline comments for specific issues.
             Avoid adding inline comments for issues that have already been addressed or are currently under discussion.
 
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
-            --model claude-opus-4-7
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*)"
+            --model claude-sonnet-4-6


### PR DESCRIPTION
## Summary

- Add `paths` filter so the Claude review workflow only fires on `contracts/**` and `test/**` changes — skips doc/config-only PRs
- Pass `EVENT` (the GitHub action type) into the prompt and instruct Claude to review only the incremental diff when a new push synchronizes an existing PR, preventing re-review of already-covered code
- Switch `fetch-depth: 1` → `0` (full history required for `git diff $before $after` on synchronize events)
- Add `Bash(git diff:*)` to allowed tools so Claude can run the incremental diff command
- Downgrade model from `claude-opus-4-7` to `claude-sonnet-4-6`

## Test plan

- [ ] Open a PR that only touches a doc file — confirm the review job does not trigger
- [ ] Open a PR touching `contracts/` — confirm the review job triggers and produces inline comments
- [ ] Push a follow-up commit to an existing open PR — confirm Claude reviews only the new diff, not the full PR again
- [ ] Verify the `git diff $before $after` command resolves correctly (requires `fetch-depth: 0`)